### PR TITLE
Make PyPI-connected Jupyter Notebooks work against all Minor Updates

### DIFF
--- a/Machine_Learning/notebooks/czmodel/Regresssion_3_0_0.ipynb
+++ b/Machine_Learning/notebooks/czmodel/Regresssion_3_0_0.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# Install czmodel and dependencies\n",
     "! pip install --upgrade pip|\n",
-    "! pip install \"czmodel>=3.0,<3.1\""
+    "! pip install \"czmodel>=3.0,<4.0\""
    ]
   },
   {

--- a/Machine_Learning/notebooks/czmodel/SingleClassSemanticSegmentation_2_0_0.ipynb
+++ b/Machine_Learning/notebooks/czmodel/SingleClassSemanticSegmentation_2_0_0.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# Install czmodel and dependencies\n",
     "! pip install --upgrade pip\n",
-    "! pip install \"czmodel>=2.0,<2.1\""
+    "! pip install \"czmodel>=2.0,<3.0\""
    ]
   },
   {

--- a/Machine_Learning/notebooks/czmodel/SingleClassSemanticSegmentation_3_0_0.ipynb
+++ b/Machine_Learning/notebooks/czmodel/SingleClassSemanticSegmentation_3_0_0.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# Install czmodel and dependencies\n",
     "! pip install --upgrade pip\n",
-    "! pip install \"czmodel>=3.0,<3.1\""
+    "! pip install \"czmodel>=3.0,<4.0\""
    ]
   },
   {

--- a/jupyter_notebooks/cztile/cztile_0_0_2.ipynb
+++ b/jupyter_notebooks/cztile/cztile_0_0_2.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Install cztile and dependencies\n",
     "! pip install --upgrade pip\n",
-    "! pip install \"cztile>=0.0,<0.1\" matplotlib tqdm scikit-image requests numpy"
+    "! pip install \"cztile>=0.0,<1.0\" matplotlib tqdm scikit-image requests numpy"
    ],
    "metadata": {
     "collapsed": false,

--- a/jupyter_notebooks/pylibCZIrw/pylibCZIrw_3_0_0.ipynb
+++ b/jupyter_notebooks/pylibCZIrw/pylibCZIrw_3_0_0.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "# Install pylibCZIrw and dependencies\n",
     "! pip install --upgrade pip\n",
-    "! pip install \"pylibCZIrw>=3.0,<3.1\" \"cztile>=0.0,<0.1\" matplotlib tqdm scikit-image pooch requests"
+    "! pip install \"pylibCZIrw>=3.0,<4.0\" \"cztile>=0.0,<1.0\" matplotlib tqdm scikit-image pooch requests"
    ]
   },
   {


### PR DESCRIPTION
Since minor updates according to [SemVer](https://semver.org/) are expected to be backward-compatible, there is no reason to restrict any of the notebooks referenced in the respective PyPI Project Descriptions to one particular minor only.