### PR TITLE
Fix image dimensions for prediction. Improve model architecture.

### DIFF
--- a/Machine_Learning/notebooks/czmodel/Regresssion_3_0_0.ipynb
+++ b/Machine_Learning/notebooks/czmodel/Regresssion_3_0_0.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "# Install czmodel and dependencies\n",
-    "! pip install --upgrade pip|\n",
+    "! pip install --upgrade pip\n",
     "! pip install \"czmodel>=3.0,<4.0\""
    ]
   },
@@ -329,22 +329,22 @@
     "# Define simple Keras convolutional model\n",
     "model = tf.keras.models.Sequential(\n",
     "    [   # Encoder\n",
-    "        tf.keras.layers.Conv2D(16, 1, activation=\"linear\", padding=\"same\"),\n",
+    "        tf.keras.layers.Conv2D(16, 3, activation=\"relu\", padding=\"same\"),\n",
     "        tf.keras.layers.MaxPooling2D(2, padding=\"same\"),\n",
-    "        tf.keras.layers.Conv2D(16, 1, activation=\"linear\", padding=\"same\"),\n",
+    "        tf.keras.layers.Conv2D(16, 3, activation=\"relu\", padding=\"same\"),\n",
     "        tf.keras.layers.MaxPooling2D(2, padding=\"same\"),\n",
-    "        tf.keras.layers.Conv2D(16, 1, activation=\"linear\", padding=\"same\"),\n",
+    "        tf.keras.layers.Conv2D(16, 3, activation=\"relu\", padding=\"same\"),\n",
     "        # Decoder\n",
     "        tf.keras.layers.UpSampling2D(2, interpolation = 'bilinear'),\n",
-    "        tf.keras.layers.Conv2D(16, 1, activation=\"linear\", padding=\"same\"),\n",
+    "        tf.keras.layers.Conv2D(16, 3, activation=\"relu\", padding=\"same\"),\n",
     "        tf.keras.layers.UpSampling2D(2, interpolation = 'bilinear'), \n",
-    "        tf.keras.layers.Conv2D(1, 3, activation=\"selu\", padding=\"same\"),\n",
+    "        tf.keras.layers.Conv2D(1, 3, activation=\"linear\", padding=\"same\"),\n",
     "    ]\n",
     ")\n",
     "\n",
     "# Compile the model\n",
     "opt = tf.keras.optimizers.Adam(learning_rate=0.001)\n",
-    "model.compile(optimizer=opt, loss='mean_absolute_error')"
+    "model.compile(optimizer=opt, loss='mean_squared_error')"
    ]
   },
   {
@@ -377,11 +377,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "hY5nMzGVrEEG",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 1000
     },
+    "id": "hY5nMzGVrEEG",
     "outputId": "81245272-1cca-4812-ce96-e966f40d909d",
     "pycharm": {
      "is_executing": true
@@ -390,7 +390,7 @@
    "outputs": [],
    "source": [
     "# Define number of training epochs\n",
-    "NUM_EPOCHS = 50\n",
+    "NUM_EPOCHS = 60\n",
     "\n",
     "# Fit the model to the data\n",
     "history = model.fit(dataset, epochs=NUM_EPOCHS)\n",
@@ -403,11 +403,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "cgU2oygWyBVC",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 309
     },
+    "id": "cgU2oygWyBVC",
     "outputId": "080cdba2-66c0-4263-cd83-af1a1cd74c12",
     "pycharm": {
      "is_executing": true
@@ -425,20 +425,20 @@
     "plt.subplot(1,3,1)\n",
     "plt.axis('off')\n",
     "plt.title('Inputs')\n",
-    "plt.imshow(image[:,:,0], cmap='gray')\n",
+    "plt.imshow(image[..., 0], cmap='gray')\n",
     "\n",
     "# Plot the predictions\n",
-    "prediction = model.predict(image)\n",
+    "prediction = model.predict(image[np.newaxis])\n",
     "plt.subplot(1,3,2)\n",
     "plt.axis('off')\n",
     "plt.title('Predictions')\n",
-    "plt.imshow(prediction[:,:,0,0], cmap='gray')\n",
+    "plt.imshow(prediction[0, ..., 0], cmap='gray')\n",
     "\n",
     "# Plot the ground truth labels\n",
     "plt.subplot(1,3,3)\n",
     "plt.axis('off')\n",
     "plt.title('Ground truth labels')\n",
-    "plt.imshow(label[:,:,0], cmap='gray')\n",
+    "plt.imshow(label[..., 0], cmap='gray')\n",
     "plt.show()"
    ]
   },
@@ -537,10 +537,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "jBMuGY9OrEEH",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "jBMuGY9OrEEH",
     "outputId": "dfeeb442-b106-4e35-c374-3b7add988be7",
     "pycharm": {
      "is_executing": true
@@ -613,10 +613,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "id": "vhDdKxxlrEEH",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "vhDdKxxlrEEH",
     "outputId": "fc04f599-6611-4757-ff15-061aa7568a4c",
     "pycharm": {
      "is_executing": true
@@ -656,6 +656,7 @@
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
   "colab": {
    "collapsed_sections": [
     "-JtOarJOrEEG"
@@ -669,9 +670,8 @@
   },
   "language_info": {
    "name": "python"
-  },
-  "accelerator": "GPU"
+  }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
The current version of the regression notebook performs the prediction without a batch dimension. This causes the prediction method produce to wrong results during prediction as the resulting tensor is of shape (512, 512, 4, 1) but is actually expected to be of shape (1, 512, 512, 1).

This PR proposes to add a batch dimension before running the prediciton method.

Furthermore, the PR improves the model architecuture and training since by applying 3x3 instead of 1x1 convolutions to better capture the influence of surrounding pixels.